### PR TITLE
Add React base 404 page

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -7,11 +7,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <link rel="stylesheet" type="text/css" href="style.css" />
+    <link rel="stylesheet" type="text/css" href="/style.css" />
   </head>
   <body>
       <div id="NYC-food-safety"></div>
-      <script src="bundle.js"></script>
+      <script src="/bundle.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
   </body>
 </html>

--- a/server/controller/error-controller.js
+++ b/server/controller/error-controller.js
@@ -1,6 +1,13 @@
+const path = require('path');
+
 exports.get = (req, res) => {
-  res.status(404);
-  res.render("404.hbs", {
-    pageTitle: "Page Not Found"
+  // res.status(404);
+  // res.render("404.hbs", {
+  //   pageTitle: "Page Not Found"
+  // });
+    res.sendFile(path.join(__dirname, "../../dist/index.html"), (err) => {
+    if (err) {
+      res.status(500).send(err);
+    }
   });
 };

--- a/src/components/404.jsx
+++ b/src/components/404.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Parallax } from "react-parallax";
+
+const NotFound = () => {
+    return (
+        <div className="hide-on-small-only">
+          <Parallax bgImage={"https://res.cloudinary.com/hg7jltnn9/image/upload/f_auto,q_auto/v1562031458/public/assets/img/kevin-curtis-3308-unsplash-1024x676_bcwbjg.jpg"} strength={500} style={{ 'height': "500px" }}>
+            {/* <div style={{ 'height': "150px" }} /> */}
+
+            <div className="container" style={{'backgroundColor': 'rgba(200,200,200,0.5)', 'padding': '30px'}}>
+                <h3 className="center" style={{'fontWeight': 'bold'}}>Page Not Found</h3>
+                <div className="row center">
+                    <h5>It looks like you were looking for a page that does not exist.</h5>    			
+                </div>
+                <div className="row center">
+                    <a href="/" className="btn-large waves-effect">GO HOME <i className="material-icons right">home</i></a>
+                </div>
+            </div>
+          </Parallax>
+        </div>
+    )
+}
+
+
+export default NotFound;

--- a/src/components/404.jsx
+++ b/src/components/404.jsx
@@ -3,11 +3,9 @@ import { Parallax } from "react-parallax";
 
 const NotFound = () => {
     return (
-        <div className="hide-on-small-only">
+        <div>
           <Parallax bgImage={"https://res.cloudinary.com/hg7jltnn9/image/upload/f_auto,q_auto/v1562031458/public/assets/img/kevin-curtis-3308-unsplash-1024x676_bcwbjg.jpg"} strength={500} style={{ 'height': "500px" }}>
-            {/* <div style={{ 'height': "150px" }} /> */}
-
-            <div className="container" style={{'backgroundColor': 'rgba(200,200,200,0.5)', 'padding': '30px'}}>
+            <div className="container" style={{'backgroundColor': 'rgba(200,200,200,0.5)', 'padding': '30px', 'marginTop': '100px'}}>
                 <h3 className="center" style={{'fontWeight': 'bold'}}>Page Not Found</h3>
                 <div className="row center">
                     <h5>It looks like you were looking for a page that does not exist.</h5>    			
@@ -20,6 +18,5 @@ const NotFound = () => {
         </div>
     )
 }
-
 
 export default NotFound;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,6 +4,7 @@ import { Route, Switch, Link, BrowserRouter as Router } from "react-router-dom";
 
 import Home from "./components/Home.jsx";
 import SearchResults from "./components/SearchResults.jsx";
+import NotFound from "./components/404.jsx";
 // import About from "./components/About.jsx";
 // import Comics from "./components/Comics.jsx";
 
@@ -48,8 +49,11 @@ class App extends React.Component {
             </div>
           </nav>
         </header>
-        <Route path="/" exact component={Home} />
-        <Route path="/search-results" exact component={SearchResults} />
+        <Switch>
+          <Route path="/" exact component={Home} />
+          <Route path="/search-results" exact component={SearchResults} />
+          <Route path="*" component={NotFound} />
+        </Switch>
         {/* <Route path="/about/" component={About} />
           <Route path="/comics/" component={Comics} /> */}
         {/* FOOTER START */}


### PR DESCRIPTION
Converted 404 page from Handlebars to React component,`<NotFound/>`

Modified `dist/index.html` to load bundle.js and style.css from absolute path rather than relative path. This prevents the client from looking for those files in the wrong directory if users visit a nested route. Previously, if a user visited `localhost:8080/pagenotfound/pagenotfound`, React tried to load `localhost:8080/pagenotfound/bundle.js` instead of the correct path, `localhost:8080/bundle.js`.