### PR TITLE
Modify borough menus

### DIFF
--- a/views/partials/advancedSearchForm.hbs
+++ b/views/partials/advancedSearchForm.hbs
@@ -9,11 +9,11 @@
 		<div class="input-field col s12 m4">
 			<select id="boro" name="boro">
 				<option value="" disabled selected>None</option>
-				<option value="BRONX">Bronx</option>
-				<option value="BROOKLYN">Brooklyn</option>
-				<option value="MANHATTAN">Manhattan</option>
-				<option value="QUEENS">Queens</option>
-				<option value="STATEN ISLAND">Staten Island</option>
+				<option value="Bronx">Bronx</option>
+				<option value="Brooklyn">Brooklyn</option>
+				<option value="Manhattan">Manhattan</option>
+				<option value="Queens">Queens</option>
+				<option value="Staten Island">Staten Island</option>
 			</select>
 			<label>Borough</label>
 		</div>		

--- a/views/partials/searchForm.hbs
+++ b/views/partials/searchForm.hbs
@@ -11,11 +11,11 @@
 			<i class="material-icons prefix">location_city</i>
 			<select id="boro" name="boro">
 				<option value="" disabled selected>None</option>
-				<option value="BRONX">Bronx</option>
-				<option value="BROOKLYN">Brooklyn</option>
-				<option value="MANHATTAN">Manhattan</option>
-				<option value="QUEENS">Queens</option>
-				<option value="STATEN ISLAND">Staten Island</option>
+				<option value="Bronx">Bronx</option>
+				<option value="Brooklyn">Brooklyn</option>
+				<option value="Manhattan">Manhattan</option>
+				<option value="Queens">Queens</option>
+				<option value="Staten Island">Staten Island</option>
 			</select>
 			<label>Borough</label>
 		</div>		

--- a/views/partials/searchFormParallax.hbs
+++ b/views/partials/searchFormParallax.hbs
@@ -16,11 +16,11 @@
                 <div class="input-field col s3">
                     {{!-- <i class="material-icons prefix">location_city</i> --}}
                     <select name="boro">
-                        <option value="BRONX">Bronx</option>
-                        <option value="BROOKLYN">Brooklyn</option>
-                        <option value="MANHATTAN">Manhattan</option>
-                        <option value="QUEENS">Queens</option>
-                        <option value="STATEN ISLAND">Staten Island</option>
+                        <option value="Bronx">Bronx</option>
+                        <option value="Brooklyn">Brooklyn</option>
+                        <option value="Manhattan">Manhattan</option>
+                        <option value="Queens">Queens</option>
+                        <option value="Staten Island">Staten Island</option>
                     </select>
                 </div>
                 <div class="input-field col s3">


### PR DESCRIPTION
Modified search forms to submit capitalized borough names instead
of all uppercase letters. See Issue #60.

This change fixed a bug where searches returned no results if user
chose a borough as a search option. This bug was due to a recent change
in NYC Open Data's restaurant violation API, which now requires borough
name queries to be capitalized instead of all caps.