### PR TITLE
Implement Redis caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ node_modules
 # Socrata API token
 token.js
 
+# Redis URL
+redisUrl.js
+
 # =========================
 # Operating System Files
 # =========================

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "express": "^4.16.4",
     "hbs": "^4.0.4",
     "lodash": "^4.17.11",
-    "morgan": "^1.9.1"
+    "morgan": "^1.9.1",
+    "redis": "^2.8.0",
+    "response-time": "^2.3.2"
   },
   "devDependencies": {
     "artillery": "^1.6.0-28",

--- a/server/controller/search-controller.js
+++ b/server/controller/search-controller.js
@@ -100,6 +100,7 @@ exports.post = (req, res) => {
 
 };
 
+// TODO: Refactor controller.post method to use getData()
 const getData = function(url) {
   // Check cache data from Redis
   client.get(url, (err, result) => {

--- a/server/controller/search-controller.js
+++ b/server/controller/search-controller.js
@@ -97,4 +97,20 @@ exports.post = (req, res) => {
     }
   });
 
+  /*
+    const getData = function (url) {
+      // check redis cache
+        // if url exists as redis key
+          // return JSON.parse(keyValue)
+        // else
+          // axios.get(url)
+            // .then(response => {
+              save url as redis key
+              save response as redis value
+              return response
+            })
+            // .catch(err)
+    }
+  */
+
 };

--- a/server/controller/search-controller.js
+++ b/server/controller/search-controller.js
@@ -98,34 +98,20 @@ exports.post = (req, res) => {
     }
   });
 
-  /*
-    const getData = function (url) {
-      // check redis cache
-        // if url exists as redis key
-          // return JSON.parse(keyValue)
-        // else
-          // axios.get(url)
-            // .then(response => {
-              save url as redis key
-              save response as redis value
-              return response
-            })
-            // .catch(err)
-    }
-  */
-
 };
 
 const getData = function(url) {
   // Check cache data from Redis
   client.get(url, (err, result) => {
     if (err) return err;
+    // if URL exists as Redis key
     if (result) {
+      // return Redis value
       return JSON.parse(result);
     } else {
       axios(url)
         .then(response => {
-            // Cache data on Redis for 1800ms
+            // Save url as Redis key, cache data on Redis for 1800ms
             client.setex(`${socrataQuery + "&" + urlQuery}`, 1800, JSON.stringify(response.data));
             return response.data;
         })

--- a/server/controller/search-controller.js
+++ b/server/controller/search-controller.js
@@ -71,6 +71,7 @@ exports.post = (req, res) => {
         .then(response => {
           let searchResults = response.data;
 
+          // Cache data on Redis for 1800ms
           client.setex(`${socrataQuery + "&" + urlQuery}`, 1800, JSON.stringify(searchResults));
           
           if (searchResults.length === 0) {
@@ -98,3 +99,21 @@ exports.post = (req, res) => {
   });
 
 };
+
+const getData = function(url) {
+  // Check cache data from Redis
+  client.get(url, (err, result) => {
+    if (err) return err;
+    if (result) {
+      return JSON.parse(result);
+    } else {
+      axios(url)
+        .then(response => {
+            // Cache data on Redis for 1800ms
+            client.setex(`${socrataQuery + "&" + urlQuery}`, 1800, JSON.stringify(response.data));
+            return response.data;
+        })
+        .catch(err => err);
+    }
+  });
+}

--- a/server/controller/search-controller.js
+++ b/server/controller/search-controller.js
@@ -3,6 +3,8 @@ const _ = require("lodash");
 const axios = require("axios");
 const querystring = require("querystring");
 const token = process.env.API_TOKEN || require("../../token.js");
+const redisUrl = process.env.REDIS_URL || require("../../redisUrl.js");
+const client = require('redis').createClient(redisUrl);
 
 // token acquired by OpenNYC Data API
 const socrataUrl = "https://data.cityofnewyork.us/resource/9w7m-hzhe.json";
@@ -44,28 +46,55 @@ exports.post = (req, res) => {
   // Merge query strings. Exclude undefined query strings.
   var urlQuery = querystring.stringify(_.merge(data));
 
-  axios(`${socrataUrl}?${socrataQuery + "&" + urlQuery}`)
-    .then(response => {
-      let searchResults = response.data;
+  // Check cache data from Redis
+  client.get(`${socrataQuery + "&" + urlQuery}`, (err, result) => {
+    let searchResults = JSON.parse(result);
+
+    if (searchResults) {
+      
       if (searchResults.length === 0) {
-        return res.render("results.hbs", {
-          pageTitle: "Search Results",
-          numberResults: "Your search returned no results."
-        });
-      } else {
-        res.render("results.hbs", {
-          pageTitle: "Search Results",
-          body: searchResults,
-          numberResults: `Your search returned ${searchResults.length} results.`
-        });
-      }
-    })
-    .catch(err => {
-      // res.status(err.response.status);
-      res.render("error.hbs", {
-        pageTitle: "Something went wrong!",
-        errorMessage:
-          "There seems to be an error. Let's go home and try something else."
-      });
-    });
+            return res.render("results.hbs", {
+              pageTitle: "Search Results",
+              numberResults: "Your search returned no results."
+            });
+          } else {
+            res.render("results.hbs", {
+              pageTitle: "Search Results",
+              body: searchResults,
+              numberResults: `Your search returned ${searchResults.length} results.`
+            });
+          }
+
+    } else {
+
+      axios(`${socrataUrl}?${socrataQuery + "&" + urlQuery}`)
+        .then(response => {
+          let searchResults = response.data;
+
+          client.setex(`${socrataQuery + "&" + urlQuery}`, 1800, JSON.stringify(searchResults));
+          
+          if (searchResults.length === 0) {
+            return res.render("results.hbs", {
+              pageTitle: "Search Results",
+              numberResults: "Your search returned no results."
+            });
+          } else {
+            res.render("results.hbs", {
+              pageTitle: "Search Results",
+              body: searchResults,
+              numberResults: `Your search returned ${searchResults.length} results.`
+            });
+          }
+        })
+        .catch(err => {
+          // res.status(err.response.status);
+          res.render("error.hbs", {
+            pageTitle: "Something went wrong!",
+            errorMessage:
+              "There seems to be an error. Let's go home and try something else."
+          });
+        });      
+    }
+  });
+
 };

--- a/server/routes/middleware-route.js
+++ b/server/routes/middleware-route.js
@@ -6,6 +6,9 @@ const bodyParser = require("body-parser"); // adds body object to request so app
 const morgan = require("morgan"); // morgan is a HTTP request logger middleware
 const compression = require("compression");
 const middleware = express.Router();
+const responseTime = require('response-time')
+
+middleware.use(responseTime()); // adds X-Response-Time header to server responses
 
 middleware.use(cors());
 // middleware.use(morgan("dev")); // log all HTTP requests in the console

--- a/views/partials/advancedSearchForm.hbs
+++ b/views/partials/advancedSearchForm.hbs
@@ -9,11 +9,11 @@
 		<div class="input-field col s12 m4">
 			<select id="boro" name="boro">
 				<option value="" disabled selected>None</option>
-				<option value="BRONX">Bronx</option>
-				<option value="BROOKLYN">Brooklyn</option>
-				<option value="MANHATTAN">Manhattan</option>
-				<option value="QUEENS">Queens</option>
-				<option value="STATEN ISLAND">Staten Island</option>
+				<option value="Bronx">Bronx</option>
+				<option value="Brooklyn">Brooklyn</option>
+				<option value="Manhattan">Manhattan</option>
+				<option value="Queens">Queens</option>
+				<option value="Staten Island">Staten Island</option>
 			</select>
 			<label>Borough</label>
 		</div>		

--- a/views/partials/searchForm.hbs
+++ b/views/partials/searchForm.hbs
@@ -11,11 +11,11 @@
 			<i class="material-icons prefix">location_city</i>
 			<select id="boro" name="boro">
 				<option value="" disabled selected>None</option>
-				<option value="BRONX">Bronx</option>
-				<option value="BROOKLYN">Brooklyn</option>
-				<option value="MANHATTAN">Manhattan</option>
-				<option value="QUEENS">Queens</option>
-				<option value="STATEN ISLAND">Staten Island</option>
+				<option value="Bronx">Bronx</option>
+				<option value="Brooklyn">Brooklyn</option>
+				<option value="Manhattan">Manhattan</option>
+				<option value="Queens">Queens</option>
+				<option value="Staten Island">Staten Island</option>
 			</select>
 			<label>Borough</label>
 		</div>		

--- a/views/partials/searchFormParallax.hbs
+++ b/views/partials/searchFormParallax.hbs
@@ -16,11 +16,11 @@
                 <div class="input-field col s3">
                     {{!-- <i class="material-icons prefix">location_city</i> --}}
                     <select name="boro">
-                        <option value="BRONX">Bronx</option>
-                        <option value="BROOKLYN">Brooklyn</option>
-                        <option value="MANHATTAN">Manhattan</option>
-                        <option value="QUEENS">Queens</option>
-                        <option value="STATEN ISLAND">Staten Island</option>
+                        <option value="Bronx">Bronx</option>
+                        <option value="Brooklyn">Brooklyn</option>
+                        <option value="Manhattan">Manhattan</option>
+                        <option value="Queens">Queens</option>
+                        <option value="Staten Island">Staten Island</option>
                     </select>
                 </div>
                 <div class="input-field col s3">


### PR DESCRIPTION
Add Redis caching to POST route `/search`. 

When a user searches for a restaurant's reports, our Node.js server checks whether the search query term exists inside our Redis cache.

If it doesn't, then the server fetches data from NYC Open Data API. The server then saves the query term as Redis cache key, with the API data as the cache value. 

But if the search query term exists as a Redis key, then the server retrieves the saved data from the Redis cache.